### PR TITLE
Update pom.xml - remove prometheus extension

### DIFF
--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -57,10 +57,6 @@
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-jdbc-postgresql</artifactId>
 		</dependency>
-		<dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-    </dependency>
 
 		<!--Distributed tracing	-->
 <!--		<dependency>-->


### PR DESCRIPTION
This fixes the issue when deploying inventory to a cluster without any Prometheus installed in the namespace: ` Message: servicemonitors.monitoring.coreos.com is forbidden: User "user2" cannot create resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "globex-keycloak-user2"`