### PR TITLE
Remove .github paths-ignore to fix Dependabot auto-merge

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,14 +6,12 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
-      - '.github/**/*.yml'
       - '.gitignore'
   pull_request:
     branches:
       - main
     paths-ignore:
       - '**/*.md'
-      - '.github/**/*.yml'
       - '.gitignore'
 
 concurrency:


### PR DESCRIPTION
## Summary
- Removed `.github/**/*.yml` from `paths-ignore` in the build-test workflow
- This fixes the root cause preventing GitHub Actions version bump PRs (e.g. actions/checkout, actions/setup-java, dependabot/fetch-metadata) from auto-merging
- When workflow files are the only changes in a PR, the required build status checks never ran, leaving PRs permanently blocked

## Context
PRs #121, #181, and #204 were stuck for months because the build checks are required by branch protection but `paths-ignore` prevented them from triggering on `.github/**/*.yml` changes.

## Test plan
- [ ] Verify this PR itself triggers all 6 required build checks
- [ ] Future Dependabot PRs that only change workflow files should auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)