### PR TITLE
Exclude major version bumps from Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        if: (steps.metadata.outputs.update-type == 'version-update:semver-patch') || (steps.metadata.outputs.update-type == 'version-update:semver-minor') || (steps.metadata.outputs.update-type == 'version-update:semver-major')
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Changed the Dependabot auto-merge workflow to only enable auto-merge for **patch** and **minor** version updates
- Previously, major version bumps (e.g. Spring Boot 3.x → 4.x, Spring Cloud 2023 → 2025) were also auto-merge-enabled, but they always fail CI since major versions contain breaking changes
- This prevents PRs like #198, #199, #201 from being stuck indefinitely with auto-merge enabled but failing builds

## Test plan
- [ ] Verify future Dependabot patch/minor PRs still get auto-merge enabled
- [ ] Verify future major version bump PRs do NOT get auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)