### PR TITLE
Bump Quarkus to 3.38.2 and fix Hibernate tracker in tests

### DIFF
--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>3.38.1</quarkus.platform.version>
+		<quarkus.platform.version>3.38.2</quarkus.platform.version>
 		<skipITs>true</skipITs>
 		<surefire-plugin.version>3.5.6</surefire-plugin.version>
 	</properties>

--- a/inventory/src/test/java/com/redhat/coolstore/inventory/controller/BlackBoxTests.java
+++ b/inventory/src/test/java/com/redhat/coolstore/inventory/controller/BlackBoxTests.java
@@ -38,7 +38,7 @@ class BlackBoxTests {
         assertThat(products)
             .isNotNull()
             .hasSize(6)
-            .usingRecursiveFieldByFieldElementComparator()
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("$$_hibernate_tracker")
             .containsExactlyElementsOf(ALL_PRODUCTS);
     }
 
@@ -53,6 +53,7 @@ class BlackBoxTests {
         assertThat(product)
             .isNotNull()
             .usingRecursiveComparison()
+            .ignoringFieldsMatchingRegexes("\\$\\$_hibernate.*")
             .isEqualTo(ALL_PRODUCTS.get(id - 1));
     }
 


### PR DESCRIPTION
## Summary
- Bumps Quarkus from 3.38.1 to 3.38.2 in `/inventory`
- Fixes `BlackBoxTests` that fail due to Hibernate's new `$$_hibernate_tracker` field breaking AssertJ recursive comparisons
- Supersedes #219 (Dependabot PR that couldn't pass CI)

## What changed
Quarkus 3.38.2 upgrades Hibernate, which now adds an internal `$$_hibernate_tracker` field to enhanced entity classes. AssertJ's `usingRecursiveComparison()` walks all fields including this tracker, and the field-set order differs between constructor-built and JSON-deserialized entities, causing false assertion failures.

Fix: ignore Hibernate-internal fields in test assertions.

## Test plan
- [ ] All 6 build matrix checks pass (inventory-17, inventory-21, gateway-17, gateway-21, orders-17, orders-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)