### PR TITLE
Bump Spring Boot to 3.5.16 and Spring Cloud to 2025.0.3

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -11,8 +11,8 @@
 		<maven.compiler.version>3.13.0</maven.compiler.version>
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-		<spring-boot.version>3.2.4</spring-boot.version>
-		<spring-cloud.version>2023.0.4</spring-cloud.version>
+		<spring-boot.version>3.5.16</spring-boot.version>
+		<spring-cloud.version>2025.0.3</spring-cloud.version>
 		<wiremock-spring-boot.version>2.1.2</wiremock-spring-boot.version>
 	</properties>
 

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -12,7 +12,7 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<otel.version>2.30.0-alpha</otel.version>
-		<spring-boot.version>3.2.4</spring-boot.version>
+		<spring-boot.version>3.5.16</spring-boot.version>
 		<dekorate.version>2.11.5.redhat-00017</dekorate.version>
 	</properties>
 


### PR DESCRIPTION
## Summary
- Coordinated upgrade of Spring Boot 3.2.4 → 3.5.16 and Spring Cloud 2023.0.4 → 2025.0.3
- **gateway**: both Spring Boot and Spring Cloud bumped
- **orders**: Spring Boot bumped (no Spring Cloud dependency)
- Supersedes #198, #199, #201 — those Dependabot PRs attempted individual major version bumps (Spring Boot 4.x / Spring Cloud 2025.1.x) that couldn't be merged independently

## Why 3.5.x instead of 4.x
Spring Boot 4.x is a major version with breaking changes (removed BOM entries, Jakarta EE 11 migration). Spring Boot 3.5.x is the latest maintained 3.x line and is a safe, non-breaking upgrade from 3.2.x. Spring Cloud 2025.0.x is the matching release train for Spring Boot 3.5.x.

## Test plan
- [ ] All 6 build matrix checks pass
- [ ] gateway tests pass (RestClient, Resilience4j circuit breaker, contract stub runner)
- [ ] orders tests pass (JPA, H2, REST Assured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)